### PR TITLE
Remove redundant param and query characters

### DIFF
--- a/include/url.h
+++ b/include/url.h
@@ -67,6 +67,11 @@ namespace Url
         // Private, unimplemented to prevent use.
         Url();
 
+        /**
+         * Remove repeated, leading, and trailing instances of chr from the string.
+         */
+        void remove_repeats(std::string& str, const char chr);
+
         std::string scheme_;
         std::string host_;
         int port_;

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -122,6 +122,8 @@ namespace Url
             if (index != std::string::npos)
             {
                 query_ = path_.substr(index + 1);
+                remove_repeats(query_, '?');
+                remove_repeats(query_, '&');
                 path_.resize(index);
             }
 
@@ -129,9 +131,28 @@ namespace Url
             if (index != std::string::npos)
             {
                 params_ = path_.substr(index + 1);
+                remove_repeats(params_, ';');
                 path_.resize(index);
             }
         }
+    }
+
+    void Url::remove_repeats(std::string& str, const char chr)
+    {
+        size_t dest = 0;
+        // By initializing this to true, it also strips of leading instances of chr
+        bool seen = true;
+        for (size_t src = 0; src < str.length(); ++src)
+        {
+            if (!seen || (str[src] != chr))
+            {
+                str[dest++] = str[src];
+            }
+            seen = str[src] == chr;
+        }
+        // Remove the last character if it happens to be chr
+        size_t length = ((dest > 0) && (str[dest - 1] == chr)) ? dest - 1 : dest;
+        str.resize(length);
     }
 
 };

--- a/test.cpp
+++ b/test.cpp
@@ -238,6 +238,21 @@ TEST(HostnameTest, LowercasesHostname)
     EXPECT_EQ("www.testing.com", Url::Url("http://www.testing.com/FOO").host());
 }
 
+TEST(QueryTest, SanitizesQuery)
+{
+    EXPECT_EQ("a=1&b=2"    , Url::Url("http://foo.com/?a=1&&&&&&b=2"   ).query());
+    EXPECT_EQ("foo=2"      , Url::Url("http://foo.com/????foo=2"       ).query());
+    EXPECT_EQ("foo=2"      , Url::Url("http://foo.com/?foo=2&&&"       ).query());
+}
+
+TEST(ParamTest, SanitizesParams)
+{
+    EXPECT_EQ(""           , Url::Url("http://foo.com/"                ).params());
+    EXPECT_EQ("a=1;b=2"    , Url::Url("http://foo.com/;a=1;;;;;;b=2"   ).params());
+    EXPECT_EQ("a=1;b=2"    , Url::Url("http://foo.com/;;;a=1;;;;;;b=2" ).params());
+    EXPECT_EQ("a=1;b=2"    , Url::Url("http://foo.com/;a=1;;;;;;b=2;;;").params());
+}
+
 int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
This is meant to provide the functionality from `url-py`:

``` python
        self.params = re.sub(r'^;+', '', str(params))
        self.params = re.sub(r'^;|;$', '', re.sub(r';{2,}', ';', self.params))
        # Strip off extra leading ?'s
        self.query = re.sub(r'^\?+', '', str(query))
        self.query = re.sub(r'^&|&$', '', re.sub(r'&{2,}', '&', self.query))
```

@b4hand @tammybailey @martin-seomoz 
