### PR TITLE
Absolutize the path

### DIFF
--- a/include/url.h
+++ b/include/url.h
@@ -63,6 +63,17 @@ namespace Url
 
         const std::string& userinfo() const { return userinfo_; }
 
+        /*********************
+         * Chainable methods *
+         *********************/
+
+        /**
+         * Make the path absolute.
+         *
+         * Evaluate '.', '..', and excessive slashes.
+         */
+        Url& abspath();
+
     private:
         // Private, unimplemented to prevent use.
         Url();

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -155,7 +155,83 @@ namespace Url
         str.resize(length);
     }
 
-    Url& Url::abspath() {
+    Url& Url::abspath()
+    {
+        std::vector<std::string> segments;
+        bool directory = false;
+        size_t previous = 0;
+        for (size_t index = path_.find('/')
+            ; index != std::string::npos
+            ; previous = index + 1, index = path_.find('/', index + 1))
+        {
+            std::string segment = path_.substr(previous, index - previous);
+
+            if (segment.empty())
+            {
+                // Skip empty segments
+                continue;
+            }
+
+            if ((index - previous == 2) && segment.compare("..") == 0)
+            {
+                if (!segments.empty())
+                {
+                    segments.pop_back();
+                }
+                directory = true;
+            }
+            else if ((index - previous == 1) && path_[previous] == '.')
+            {
+                directory = true;
+            }
+            else
+            {
+                segments.push_back(segment);
+                directory = false;
+            }
+        }
+
+        // Handle the last segment
+        std::string segment = path_.substr(previous);
+        if (segment.empty() || segment.compare(".") == 0)
+        {
+            directory = true;
+        }
+        else if (segment.compare("..") == 0)
+        {
+            if (!segments.empty())
+            {
+                segments.pop_back();
+            }
+            directory = true;
+        }
+        else
+        {
+            segments.push_back(segment);
+            directory = false;
+        }
+
+        // Assemble the new path
+        if (segments.empty())
+        {
+            path_ = directory ? "/" : "";
+        }
+        else
+        {
+            std::string copy;
+            for (auto it = segments.begin(); it != segments.end(); ++it)
+            {
+                copy.append("/");
+                copy.append(*it);
+            }
+            if (directory)
+            {
+                copy.append("/");
+            }
+            path_ = copy;
+        }
+
         return *this;
     }
+
 };

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -155,4 +155,7 @@ namespace Url
         str.resize(length);
     }
 
+    Url& Url::abspath() {
+        return *this;
+    }
 };

--- a/test.cpp
+++ b/test.cpp
@@ -253,6 +253,114 @@ TEST(ParamTest, SanitizesParams)
     EXPECT_EQ("a=1;b=2"    , Url::Url("http://foo.com/;a=1;;;;;;b=2;;;").params());
 }
 
+TEST(AbspathTest, BasicPath)
+{
+    EXPECT_EQ("/howdy",
+        Url::Url("http://foo.com/howdy").abspath().path());
+}
+
+TEST(AbspathTest, RepeatedSeparator)
+{
+    EXPECT_EQ("/hello/how/are",
+        Url::Url("http://foo.com/hello//how//are").abspath().path());
+}
+
+TEST(AbspathTest, ParentDirectory)
+{
+    EXPECT_EQ("/how/are",
+        Url::Url("http://foo.com/hello/../how/are").abspath().path());
+}
+
+TEST(AbspathTest, ParentDirectoryWithRepeatedSeparators)
+{
+    EXPECT_EQ("/how/",
+        Url::Url("http://foo.com/hello//..//how/").abspath().path());
+}
+
+TEST(AbspathTest, GrandparentDirectory)
+{
+    EXPECT_EQ("/c",
+        Url::Url("http://foo.com/a/b/../../c").abspath().path());
+}
+
+TEST(AbspathTest, UpMoreLevelsThanSegments)
+{
+    EXPECT_EQ("/c",
+        Url::Url("http://foo.com/../../../c").abspath().path());
+}
+
+TEST(AbspathTest, CurrentDirectory)
+{
+    EXPECT_EQ("/hello",
+        Url::Url("http://foo.com/./hello").abspath().path());
+}
+
+TEST(AbspathTest, CurrentDirectoryRepeated)
+{
+    EXPECT_EQ("/hello",
+        Url::Url("http://foo.com/./././hello").abspath().path());
+}
+
+TEST(AbspathTest, MultipleSegmentsDirectory)
+{
+    EXPECT_EQ("/a/b/c/",
+        Url::Url("http://foo.com/a/b/c/").abspath().path());
+}
+
+TEST(AbspathTest, TrailingParentDirectory)
+{
+    EXPECT_EQ("/a/b/",
+        Url::Url("http://foo.com/a/b/c/..").abspath().path());
+}
+
+TEST(AbspathTest, TrailingCurrentDirectory)
+{
+    EXPECT_EQ("/a/b/",
+        Url::Url("http://foo.com/a/b/.").abspath().path());
+}
+
+TEST(AbspathTest, TrailingCurrentDirectoryMultiple)
+{
+    EXPECT_EQ("/a/b/",
+        Url::Url("http://foo.com/a/b/./././").abspath().path());
+}
+
+TEST(AbspathTest, TrailingParentDirectorySlash)
+{
+    EXPECT_EQ("/a/",
+        Url::Url("http://foo.com/a/b/../").abspath().path());
+}
+
+TEST(AbspathTest, OnlyCurrentDirectory)
+{
+    EXPECT_EQ("/",
+        Url::Url("http://foo.com/.").abspath().path());
+}
+
+TEST(AbspathTest, OnlyMultipleParentDirectories)
+{
+    EXPECT_EQ("/",
+        Url::Url("http://foo.com/../../..").abspath().path());
+}
+
+TEST(AbspathTest, TrailingDotInLastSegment)
+{
+    EXPECT_EQ("/whiz.",
+        Url::Url("http://foo.com//foo/../whiz.").abspath().path());
+}
+
+TEST(AbspathTest, TrailingDotInSegmentSlash)
+{
+    EXPECT_EQ("/foo/whiz./",
+        Url::Url("http://foo.com//foo/whiz./").abspath().path());
+}
+
+TEST(AbspathTest, TrailingDotInSegment)
+{
+    EXPECT_EQ("/foo/whiz./bar",
+        Url::Url("http://foo.com//foo/whiz./bar").abspath().path());
+}
+
 int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
The `abspath` method evaluates `.` and `..` and removes redundant slashes in the path.

@b4hand @tanglyh @martin-seomoz @tammybailey 
