### PR TITLE
Don't aggressively replace ?'s in the query

### DIFF
--- a/src/url.cpp
+++ b/src/url.cpp
@@ -121,9 +121,16 @@ namespace Url
             index = path_.find('?');
             if (index != std::string::npos)
             {
-                query_ = path_.substr(index + 1);
-                remove_repeats(query_, '?');
-                remove_repeats(query_, '&');
+                size_t start = path_.find_first_not_of('?', index + 1);
+                if (start != std::string::npos)
+                {
+                    query_ = path_.substr(start);
+                    remove_repeats(query_, '&');
+                }
+                else
+                {
+                    query_ = "";
+                }
                 path_.resize(index);
             }
 

--- a/test.cpp
+++ b/test.cpp
@@ -259,6 +259,9 @@ TEST(QueryTest, SanitizesQuery)
     EXPECT_EQ("a=1&b=2"    , Url::Url("http://foo.com/?a=1&&&&&&b=2"   ).query());
     EXPECT_EQ("foo=2"      , Url::Url("http://foo.com/????foo=2"       ).query());
     EXPECT_EQ("foo=2"      , Url::Url("http://foo.com/?foo=2&&&"       ).query());
+    EXPECT_EQ("query?"     , Url::Url("http://foo.com/?query?"         ).query());
+    EXPECT_EQ("repeats???q", Url::Url("http://foo.com/?repeats???q"    ).query());
+    EXPECT_EQ(""           , Url::Url("http://foo.com/?????"           ).query());
 }
 
 TEST(ParamTest, SanitizesParams)


### PR DESCRIPTION
@b4hand @vadim-moz @tanglyh 

It came up first in #3 , but it turns out the current implementation of `url-py` does not so aggressively remove `?` characters from the query. In a test of URLs taken from the wild, this accounted for many of the differences between `url-py` and `url-cpp`.
