### PR TITLE
Benchmarking and some performance improvements

### DIFF
--- a/bench.cpp
+++ b/bench.cpp
@@ -1,0 +1,68 @@
+#include <iostream>
+#include <chrono>
+#include <ctime>
+
+#include "url.h"
+
+/**
+ * Run func() `count` times in each of `runs` experiments, where `name` provides a
+ * meaningful description of the task being benchmarked. Prints out the time for each
+ * run, the average time, and rate.
+ */
+template<typename Functor>
+void bench(const std::string& name, size_t count, size_t runs, Functor func)
+{
+    std::cout << "Benchmarking " << name << " with " << count << " per run:" << std::endl;
+    double total(0);
+    for (size_t run = 0; run < runs; ++run)
+    {
+        auto start = std::chrono::high_resolution_clock::now();
+        for (size_t it = 0; it < count; ++it)
+        {
+            func();
+        }
+        auto end = std::chrono::high_resolution_clock::now();
+        double duration = std::chrono::duration<double, std::milli>(end - start).count();
+        total += duration;
+        std::cout << "    Run " << run << ": " << duration << " ms" << std::endl;
+    }
+    std::cout << "  Average: " << (total / runs) << " ms" << std::endl;
+    std::cout << "     Rate: " << ((count * runs) / total) << " k-iter / s" << std::endl;
+}
+
+int main(int argc, char* argv[]) {
+    if (argc != 3) {
+        std::cerr << "bench <base> <relative>" << std::endl;
+        std::cerr << "  Benchmark various transforms of base + relative." << std::endl;
+        return 1;
+    }
+
+    std::string base(argv[1]);
+    std::string relative(argv[2]);
+
+    size_t count = 1000000;
+    size_t runs = 5;
+
+    Url::Url base_url(base);
+    std::string full = Url::Url(relative).relative_to(base_url).str();
+
+    bench("parse", count, runs, [full]() {
+        Url::Url parsed(full);
+    });
+
+    bench("relative", count, runs, [base_url, relative]() {
+        Url::Url(relative).relative_to(base_url);
+    });
+
+    bench("parse + escape", count, runs, [full]() {
+        Url::Url(full).escape();
+    });
+
+    bench("parse + abspath", count, runs, [full]() {
+        Url::Url(full).abspath();
+    });
+
+    bench("parse + punycode", count, runs, [full]() {
+        Url::Url(full).punycode();
+    });
+}

--- a/include/url.h
+++ b/include/url.h
@@ -15,22 +15,51 @@ namespace Url
         UrlParseException(const std::string& message) : std::logic_error(message) {}
     };
 
+    struct CharacterClass
+    {
+        CharacterClass(const std::string& chars) : chars_(chars), map_(256, false)
+        {
+            for (auto it = chars_.begin(); it != chars_.end(); ++it)
+            {
+                map_[static_cast<size_t>(*it)] = true;
+            }
+        }
+
+        bool operator()(char c) const
+        {
+            return map_[static_cast<unsigned char>(c)];
+        }
+
+        const std::string& chars() const
+        {
+            return chars_;
+        }
+
+    private:
+        // Private, unimplemented to prevent use
+        CharacterClass();
+        CharacterClass(const CharacterClass& other);
+
+        std::string chars_;
+        std::vector<bool> map_;
+    };
+
     struct Url
     {
         /* Character classes */
-        const static std::string GEN_DELIMS;
-        const static std::string SUB_DELIMS;
-        const static std::string ALPHA;
-        const static std::string DIGIT;
-        const static std::string UNRESERVED;
-        const static std::string RESERVED;
-        const static std::string PCHAR;
-        const static std::string PATH;
-        const static std::string QUERY;
-        const static std::string FRAGMENT;
-        const static std::string USERINFO;
-        const static std::string HEX;
-        const static std::string SCHEME;
+        const static CharacterClass GEN_DELIMS;
+        const static CharacterClass SUB_DELIMS;
+        const static CharacterClass ALPHA;
+        const static CharacterClass DIGIT;
+        const static CharacterClass UNRESERVED;
+        const static CharacterClass RESERVED;
+        const static CharacterClass PCHAR;
+        const static CharacterClass PATH;
+        const static CharacterClass QUERY;
+        const static CharacterClass FRAGMENT;
+        const static CharacterClass USERINFO;
+        const static CharacterClass HEX;
+        const static CharacterClass SCHEME;
         const static std::vector<signed char> HEX_TO_DEC;
         const static std::unordered_map<std::string, int> PORTS;
 
@@ -147,7 +176,7 @@ namespace Url
         /**
          * Ensure all the provided characters are escaped if necessary
          */
-        void escape(std::string& str, const std::string& safe, bool strict);
+        void escape(std::string& str, const CharacterClass& safe, bool strict);
 
         /**
          * Remove any params that match entries in the blacklist.


### PR DESCRIPTION
Some benchmarking results are here: https://docs.google.com/spreadsheets/d/1I7QycnED7qC8MK8qoiSu8SkrTkAj1xqBPcSXziozo7M/edit#gid=0

They show the absolute and relative performance of python and different SHAs to do various things to a URL (parse, escape, abspath, etc.) 1M times. They are grouped by example URL (`base` and `relative`), and highlighted cells show what metrics were specifically targeted for optimization by a particular commit.

There are more opportunities for improvement, but I think I'll table this for now.

@b4hand @neilmb @martin-seomoz @tammybailey @tanglyh 
