### PR TITLE
Canonical

### DIFF
--- a/include/url.h
+++ b/include/url.h
@@ -140,6 +140,13 @@ namespace Url
         Url& deparam(const std::unordered_set<std::string>& blacklist);
 
         /**
+         * Put queries and params in sorted order.
+         *
+         * To ensure consistent comparisons, escape should be called beforehand.
+         */
+        Url& sort_query();
+
+        /**
          * Remove the port if it's the default for the scheme.
          */
         Url& remove_default_port();

--- a/include/url.h
+++ b/include/url.h
@@ -190,6 +190,11 @@ namespace Url
          */
         void remove_params(std::string& str, const std::unordered_set<std::string>& blacklist, const char separator);
 
+        /**
+         * Split the provided string by char, sort, join by char.
+         */
+        void split_sort_join(std::string& str, const char glue);
+
         std::string scheme_;
         std::string host_;
         int port_;

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -4,6 +4,8 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <iostream>
+#include <iterator>
+#include <sstream>
 
 #include "url.h"
 #include "punycode.h"
@@ -525,7 +527,45 @@ namespace Url
 
     Url& Url::sort_query()
     {
+        split_sort_join(query_, '&');
+        split_sort_join(params_, ';');
         return *this;
+    }
+
+    void Url::split_sort_join(std::string& str, const char glue)
+    {
+        // Return early if empty
+        if (str.empty())
+        {
+            return;
+        }
+
+        // Split
+        std::vector<std::string> pieces;
+        std::stringstream stream(str);
+        std::string item;
+        while (getline(stream, item, glue))
+        {
+            pieces.push_back(item);
+        }
+
+        // Return early if it's just a single element
+        if (pieces.size() == 1)
+        {
+            return;
+        }
+
+        // Sort
+        std::sort(pieces.begin(), pieces.end());
+
+        // Join (at this point we know that there's at least one element)
+        std::stringstream output;
+        for (auto it = pieces.begin(); it != (pieces.end() - 1); ++it)
+        {
+            output << *it << glue;
+        }
+        output << pieces.back();
+        str.assign(output.str());
     }
 
     Url& Url::remove_default_port()

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -523,6 +523,11 @@ namespace Url
         str.assign(copy);
     }
 
+    Url& Url::sort_query()
+    {
+        return *this;
+    }
+
     Url& Url::remove_default_port()
     {
         if (port_ && !scheme_.empty())

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -727,6 +727,36 @@ TEST(FilterParams, CaseInsensitivity)
     EXPECT_EQ("", Url::Url("?HELLo=2").deparam(blacklist).str());
 }
 
+TEST(SortQueryTest, SortsQueries)
+{
+    EXPECT_EQ("http://foo.com/?a=1&b=2&c=3",
+        Url::Url("http://foo.com/?b=2&c=3&a=1").sort_query().str());
+}
+
+TEST(SortQueryTest, SortsParams)
+{
+    EXPECT_EQ("http://foo.com/;a=1;b=2;c=3",
+        Url::Url("http://foo.com/;b=2;c=3;a=1").sort_query().str());
+}
+
+TEST(SortQueryTest, Empty)
+{
+    EXPECT_EQ("http://foo.com/",
+        Url::Url("http://foo.com/").sort_query().str());
+}
+
+TEST(SortQueryTest, SingleQuery)
+{
+    EXPECT_EQ("http://foo.com/?a=7",
+        Url::Url("http://foo.com/?a=7").sort_query().str());
+}
+
+TEST(SortQueryTest, SingleParam)
+{
+    EXPECT_EQ("http://foo.com/;a=7",
+        Url::Url("http://foo.com/;a=7").sort_query().str());
+}
+
 TEST(RemoveDefaultPortTest, HttpTest)
 {
     EXPECT_EQ("http://foo.com/",


### PR DESCRIPTION
As I started wrapping this in `url-py`, I realized I needed `canonical`, which sorts `query` and `params`.

@lindseyreno @b4hand @tammybailey @tanglyh @martin-seomoz 
