### PR TITLE
Expose setters

### DIFF
--- a/include/url.h
+++ b/include/url.h
@@ -75,24 +75,64 @@ namespace Url
             , fragment_(other.fragment_)
             , userinfo_(other.userinfo_) { }
 
-        /**************************
-         * Component-wise access. *
-         **************************/
+        /**************************************
+         * Component-wise access and setting. *
+         **************************************/
         const std::string& scheme() const { return scheme_; }
+        Url& setScheme(const std::string& s)
+        {
+            scheme_ = s;
+            return *this;
+        }
 
         const std::string& host() const { return host_; }
+        Url& setHost(const std::string& s)
+        {
+            host_ = s;
+            return *this;
+        }
 
         const int port() const { return port_; }
+        Url& setPort(int i)
+        {
+            port_ = i;
+            return *this;
+        }
 
         const std::string& path() const { return path_; }
+        Url& setPath(const std::string& s)
+        {
+            path_ = s;
+            return *this;
+        }
 
         const std::string& params() const { return params_; }
+        Url& setParams(const std::string& s)
+        {
+            params_ = s;
+            return *this;
+        }
 
         const std::string& query() const { return query_; }
+        Url& setQuery(const std::string& s)
+        {
+            query_ = s;
+            return *this;
+        }
 
         const std::string& fragment() const { return fragment_; }
+        Url& setFragment(const std::string& s)
+        {
+            fragment_ = s;
+            return *this;
+        }
 
         const std::string& userinfo() const { return userinfo_; }
+        Url& setUserinfo(const std::string& s)
+        {
+            userinfo_ = s;
+            return *this;
+        }
 
         /**
          * Get a new string representation of the URL.

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -247,6 +247,54 @@ TEST(ParseTest, TestPortNotNumber)
     ASSERT_THROW(Url::Url("http://www.python.org:80hello/"), Url::UrlParseException);
 }
 
+TEST(SetAttributesTest, Scheme)
+{
+    EXPECT_EQ("https://host.name/",
+        Url::Url("http://host.name/").setScheme("https").str());
+}
+
+TEST(SetAttributesTest, Userinfo)
+{
+    EXPECT_EQ("http://name@host.name/",
+        Url::Url("http://user@host.name/").setUserinfo("name").str());
+}
+
+TEST(SetAttributesTest, Host)
+{
+    EXPECT_EQ("http://new.host/",
+        Url::Url("http://old.host/").setHost("new.host").str());
+}
+
+TEST(SetAttributesTest, Port)
+{
+    EXPECT_EQ("http://host.name:8080/",
+        Url::Url("http://host.name/").setPort(8080).str());
+}
+
+TEST(SetAttributesTest, Path)
+{
+    EXPECT_EQ("http://host.name/new/path",
+        Url::Url("http://host.name/old/path").setPath("/new/path").str());
+}
+
+TEST(SetAttributesTest, Params)
+{
+    EXPECT_EQ("http://host.name/;new;params",
+        Url::Url("http://host.name/;old;params").setParams("new;params").str());
+}
+
+TEST(SetAttributesTest, Query)
+{
+    EXPECT_EQ("http://host.name/?new=query",
+        Url::Url("http://host.name/?old=query").setQuery("new=query").str());
+}
+
+TEST(SetAttributesTest, Fragment)
+{
+    EXPECT_EQ("http://host.name/#new-fragment",
+        Url::Url("http://host.name/#old-fragment").setFragment("new-fragment").str());
+}
+
 TEST(HostnameTest, LowercasesHostname)
 {
     EXPECT_EQ("www.testing.com", Url::Url("http://www.TESTING.coM").host());


### PR DESCRIPTION
`url-py` has a `filter_params` which takes a predicate to determine whether a `query` or `param` should be filtered. But we can't pass a python predicate down to `url-cpp` (at least without quite some gymnastics), so one way out is to provide a setter for `query` and `params`.

@b4hand @tammybailey @tanglyh @martin-seomoz 
