### PR TITLE
Unescape

### DIFF
--- a/include/url.h
+++ b/include/url.h
@@ -172,6 +172,11 @@ namespace Url
         Url& escape(bool strict=false);
 
         /**
+         * Unescape all entities in the path, params, query, and userinfo.
+         */
+        Url& unescape();
+
+        /**
          * Remove any params or queries that appear in the blacklist.
          *
          * The blacklist should contain only lowercased strings, and the comparison is

--- a/include/url.h
+++ b/include/url.h
@@ -231,6 +231,11 @@ namespace Url
         void escape(std::string& str, const CharacterClass& safe, bool strict);
 
         /**
+         * Unescape entities in the provided string
+         */
+        void unescape(std::string& str);
+
+        /**
          * Remove any params that match entries in the blacklist.
          */
         void remove_params(std::string& str, const std::unordered_set<std::string>& blacklist, const char separator);

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -478,7 +478,40 @@ namespace Url
 
     Url& Url::unescape()
     {
+        unescape(path_);
+        unescape(query_);
+        unescape(params_);
+        unescape(userinfo_);
         return *this;
+    }
+
+    void Url::unescape(std::string& str)
+    {
+        std::string copy(str);
+        size_t dest = 0;
+        for (size_t src = 0; src < copy.length(); ++src, ++dest)
+        {
+            if (copy[src] == '%' && (copy.length() - src) >= 2)
+            {
+                // Read ahead to see if there's a valid escape sequence. If not, treat
+                // this like a normal character.
+                if (HEX_TO_DEC[copy[src+1]] != -1 && HEX_TO_DEC[copy[src+2]] != -1)
+                {
+                    int value = (
+                        HEX_TO_DEC[copy[src+1]] * 16 + HEX_TO_DEC[copy[src+2]]);
+
+                    // Replace src + 2 with that byte, advance src to consume it and
+                    // continue.
+                    src += 2;
+                    str[dest] = value;
+                    continue;
+                }
+            }
+            
+            // Either not a % or an incomplete entity
+            str[dest] = copy[src];
+        }
+        str.resize(dest);
     }
 
     Url& Url::deparam(const std::unordered_set<std::string>& blacklist)

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -476,6 +476,11 @@ namespace Url
         str.resize(dest);
     }
 
+    Url& Url::unescape()
+    {
+        return *this;
+    }
+
     Url& Url::deparam(const std::unordered_set<std::string>& blacklist)
     {
         remove_params(params_, blacklist, ';');

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -752,6 +752,33 @@ TEST(EscapeTest, StrictFromUrlPy)
         Url::Url("http://user%3apass@foo.com/").escape(true).str());
 }
 
+TEST(UnescapeTest, KeepUnescaped)
+{
+    EXPECT_EQ("this's a test",
+        Url::Url("this's%20a%20test").unescape().str());
+}
+
+TEST(UnescapeTest, IncompleteEntity)
+{
+    EXPECT_EQ("incomplete entity %2",
+        Url::Url("incomplete%20entity%20%2").unescape().str());
+}
+
+TEST(UnescapeTest, NonHexEntity)
+{
+    EXPECT_EQ("a non hex %gh entity",
+        Url::Url("a%20non%20hex%20%gh%20entity").unescape().str());
+}
+
+TEST(UnescapeTest, UnescapesEverything)
+{
+    std::string escaped =
+        "http://hei%C3%9Fe@domain.com/s%C3%B8me%3Bw%C3%A9ird%3Fex%C3%A5mple";
+    std::string unescaped =
+        "http://hei\xc3\x9f" "e@domain.com/s\xc3\xb8me;w\xc3\xa9ird?ex\xc3\xa5mple";
+    EXPECT_EQ(unescaped, Url::Url(escaped).unescape().str());
+}
+
 TEST(FilterParams, FiltersQuery)
 {
     std::unordered_set<std::string> blacklist = {"c"};


### PR DESCRIPTION
Replace all escaped entities with their corresponding byte value.

@b4hand @tammybailey @tanglyh @martin-seomoz 
