### PR TITLE
Filter Params

### DIFF
--- a/include/url.h
+++ b/include/url.h
@@ -2,6 +2,7 @@
 #define URL_CPP_H
 
 #include <stdexcept>
+#include <functional>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -62,6 +63,9 @@ namespace Url
         const static CharacterClass SCHEME;
         const static std::vector<signed char> HEX_TO_DEC;
         const static std::unordered_map<std::string, int> PORTS;
+
+        // The type of the predicate used for removing parameters
+        typedef std::function<bool(std::string&, std::string&)> deparam_predicate;
 
         explicit Url(const std::string& url);
 
@@ -185,6 +189,15 @@ namespace Url
         Url& deparam(const std::unordered_set<std::string>& blacklist);
 
         /**
+         * Filter params subject to a predicate for whether it should be filtered.
+         *
+         * The predicate must accept two string refs -- the key and value (which may be
+         * empty). Return `true` if the parameter should be removed, and `false`
+         * otherwise.
+         */
+        Url& deparam(const deparam_predicate& predicate);
+
+        /**
          * Put queries and params in sorted order.
          *
          * To ensure consistent comparisons, escape should be called beforehand.
@@ -238,7 +251,7 @@ namespace Url
         /**
          * Remove any params that match entries in the blacklist.
          */
-        void remove_params(std::string& str, const std::unordered_set<std::string>& blacklist, const char separator);
+        void remove_params(std::string& str, const deparam_predicate& pred, char sep);
 
         /**
          * Split the provided string by char, sort, join by char.

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -539,7 +539,7 @@ namespace Url
                             const deparam_predicate& predicate,
                             char sep)
     {
-        std::vector<std::string> pieces;
+        std::string copy;
         std::string piece;
         std::string name;
         std::string value;
@@ -559,7 +559,8 @@ namespace Url
 
             if (!predicate(name, value))
             {
-                pieces.push_back(piece);
+                copy.append(copy.empty() ? 0 : 1, sep);
+                copy.append(piece);
             }
         }
 
@@ -576,20 +577,11 @@ namespace Url
 
             if (!predicate(name, value))
             {
-                pieces.push_back(piece);
+                copy.append(copy.empty() ? 0 : 1, sep);
+                copy.append(piece);
             }
         }
 
-        std::string copy;
-        for (auto it = pieces.begin(); it != pieces.end();)
-        {
-            copy.append(*it);
-            for (++it; it != pieces.end(); ++it)
-            {
-                copy.append(1, sep);
-                copy.append(*it);
-            }
-        }
         str.assign(copy);
     }
 

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -86,7 +86,7 @@ namespace Url
                         url.end(),
                         [](char c) { return !DIGIT(c); }))
                 {
-                    scheme_ = url.substr(0, index);
+                    scheme_.assign(url, 0, index);
                     std::transform(
                         scheme_.begin(), scheme_.end(), scheme_.begin(), ::tolower);
                     position = index + 1;
@@ -102,15 +102,15 @@ namespace Url
             // Skip the '//'
             position += 2;
             index = url.find_first_of("/?#", position);
-            host_ = url.substr(position, index - position);
+            host_.assign(url, position, index - position);
             position = index;
 
             // Extract any userinfo if there is any
             index = host_.find('@');
             if (index != std::string::npos)
             {
-                userinfo_ = host_.substr(0, index);
-                host_ = host_.substr(index + 1);
+                userinfo_.assign(host_, 0, index);
+                host_.assign(host_, index + 1, std::string::npos);
             }
             
             // Lowercase the hostname
@@ -120,7 +120,7 @@ namespace Url
             index = host_.find(':');
             if (index != std::string::npos)
             {
-                std::string portText = host_.substr(index + 1);
+                std::string portText(host_, index + 1, std::string::npos);
                 host_.resize(index);
 
                 if (portText.empty())
@@ -158,12 +158,12 @@ namespace Url
 
         if (position != std::string::npos)
         {
-            path_ = url.substr(position);
+            path_.assign(url, position, std::string::npos);
 
             index = path_.find('#');
             if (index != std::string::npos)
             {
-                fragment_ = path_.substr(index + 1);
+                fragment_.assign(path_, index + 1, std::string::npos);
                 path_.resize(index);
             }
 
@@ -173,7 +173,7 @@ namespace Url
                 size_t start = path_.find_first_not_of('?', index + 1);
                 if (start != std::string::npos)
                 {
-                    query_ = path_.substr(start);
+                    query_.assign(path_, start, std::string::npos);
                     remove_repeats(query_, '&');
                 }
                 else
@@ -186,7 +186,7 @@ namespace Url
             index = path_.find(';');
             if (index != std::string::npos)
             {
-                params_ = path_.substr(index + 1);
+                params_.assign(path_, index + 1, std::string::npos);
                 remove_repeats(params_, ';');
                 path_.resize(index);
             }
@@ -391,7 +391,7 @@ namespace Url
             }
             else
             {
-                path_ = other.path_.substr(0, other.path_.rfind('/') + 1);
+                path_.assign(other.path_, 0, other.path_.rfind('/') + 1);
             }
 
             if (fragment_.empty())
@@ -548,16 +548,13 @@ namespace Url
             ; index != std::string::npos
             ; previous = index + 1, index = str.find(sep, previous))
         {
-            piece = str.substr(previous, index - previous);
+            piece.assign(str, previous, index - previous);
             size_t position = piece.find('=');
-            name = piece.substr(0, position);
+            name.assign(piece, 0, position);
+            value.clear();
             if (position != std::string::npos)
             {
-                value = piece.substr(position + 1);
-            }
-            else
-            {
-                value.clear();
+                value.assign(piece, position + 1, std::string::npos);
             }
 
             if (!predicate(name, value))
@@ -568,16 +565,13 @@ namespace Url
 
         if (previous < str.length())
         {
-            piece = str.substr(previous);
+            piece.assign(str, previous, std::string::npos);
             size_t position = piece.find('=');
-            name = piece.substr(0, position);
+            name.assign(piece, 0, position);
+            value.clear();
             if (position != std::string::npos)
             {
-                value = piece.substr(position + 1);
-            }
-            else
-            {
-                value.clear();
+                value.assign(piece, position + 1, std::string::npos);
             }
 
             if (!predicate(name, value))

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -802,6 +802,28 @@ TEST(FilterParams, CaseInsensitivity)
     EXPECT_EQ("", Url::Url("?HELLo=2").deparam(blacklist).str());
 }
 
+TEST(FilterParams, PredicateFormQuery)
+{
+    auto predicate = [](std::string& name, std::string& value)
+    {
+        // Remove parameters with the value 2 or with "foo" in the name
+        return (value == "2") || (name.find("foo") != std::string::npos);
+    };
+    EXPECT_EQ("?a=1&c=3",
+        Url::Url("?a=1&b=2&c=3&not-foo&yes-foo=18").deparam(predicate).str());
+}
+
+TEST(FilterParams, PredicateFormParams)
+{
+    auto predicate = [](std::string& name, std::string& value)
+    {
+        // Remove parameters with the value 2 or with "foo" in the name
+        return (value == "2") || (name.find("foo") != std::string::npos);
+    };
+    EXPECT_EQ(";a=1;c=3",
+        Url::Url(";a=1;b=2;c=3;not-foo;yes-foo=18").deparam(predicate).str());
+}
+
 TEST(SortQueryTest, SortsQueries)
 {
     EXPECT_EQ("http://foo.com/?a=1&b=2&c=3",


### PR DESCRIPTION
While we might want to remove some parameters by blacklist, we sometimes need more nuanced control (for instance, `mozscape` removes parameters and queries that look like URLs). To that end, there's a version of `deparam` that accepts a predicate that determines whether a `name, value` pair should be filtered out of a URL.

@tammybailey @lindseyreno @b4hand
