### PR TITLE
Punycode speed improvements

### DIFF
--- a/bench.cpp
+++ b/bench.cpp
@@ -44,7 +44,8 @@ int main(int argc, char* argv[]) {
     size_t runs = 5;
 
     Url::Url base_url(base);
-    std::string full = Url::Url(relative).relative_to(base_url).str();
+    Url::Url full_url = Url::Url(relative).relative_to(base_url);
+    std::string full = full_url.str();
 
     bench("parse", count, runs, [full]() {
         Url::Url parsed(full);
@@ -64,5 +65,9 @@ int main(int argc, char* argv[]) {
 
     bench("parse + punycode", count, runs, [full]() {
         Url::Url(full).punycode();
+    });
+
+    bench("punycode + unpunycode", count, runs, [full_url]() mutable {
+        full_url.punycode().unpunycode();
     });
 }

--- a/include/punycode.h
+++ b/include/punycode.h
@@ -54,8 +54,12 @@ namespace Url
 
         // The highest codepoint in unicode
         const punycode_uint MAX_PUNYCODE_UINT = std::numeric_limits<punycode_uint>::max();
-        //Utf8::MAX_CODEPOINT;
-        //std::numeric_limits<punycode_uint>::max();
+
+        /**
+         * Punycode the utf-8-encoded begin->end and append it to str.
+         */
+        std::string& encode(std::string& str, std::string::const_iterator begin,
+            std::string::const_iterator end);
 
         /**
          * Replace utf-8-encoded str into punycode.
@@ -66,6 +70,12 @@ namespace Url
          * Create a new punycoded string from utf-8-encoded input.
          */
         std::string encode(const std::string& str);
+
+        /**
+         * Append the utf-8-version of the punycoded string between begin and end to str.
+         */
+        std::string& decode(std::string& str, std::string::const_iterator begin,
+            std::string::const_iterator end);
 
         /**
          * Replace punycoded str into utf-8-encoded.
@@ -81,6 +91,12 @@ namespace Url
          * Determine if a string needs punycoding.
          */
         bool needsPunycoding(const std::string& str);
+
+        /**
+         * Determine if the characters between these two iterators needs punycoding.
+         */
+        bool needsPunycoding(const std::string::const_iterator& begin,
+                             const std::string::const_iterator& end);
 
         /**
          * Internal function for calculating bias.

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -1108,6 +1108,18 @@ TEST(DefragTest, Defrag)
         Url::Url("http://foo.com/path#fragment").defrag().str());
 }
 
+TEST(PunycodeTest, UnpunycodeShortIdentifierAtEnd)
+{
+    std::string example("http://www.xn-/");
+    EXPECT_EQ(example, Url::Url(example).unpunycode().str());
+}
+
+TEST(PunycodeTest, UnpunycodeShortIdentifierAtStart)
+{
+    std::string example("http://xn-.com/");
+    EXPECT_EQ(example, Url::Url(example).unpunycode().str());
+}
+
 TEST(PunycodeTest, German)
 {
     std::string unencoded("http://www.kündigen.de/");


### PR DESCRIPTION
I had this hanging around on a branch, and I figured I should pull it forward now rather than let linger. A rough benchmark using the input `"http://日本.co.jp" "/page"`:

```
Old:
Benchmarking parse + punycode with 1000000 per run:
  Average: 1043.73 ms
     Rate: 958.101 k-iter / s
Benchmarking punycode + unpunycode with 1000000 per run:
  Average: 1566.77 ms
     Rate: 638.256 k-iter / s

New:
Benchmarking parse + punycode with 1000000 per run:
  Average: 727.279 ms
     Rate: 1374.99 k-iter / s
Benchmarking punycode + unpunycode with 1000000 per run:
  Average: 946.035 ms
     Rate: 1057.04 k-iter / s
```

@b4hand @tammybailey @lindseyreno 
