### PR TITLE
Check segment lengths

### DIFF
--- a/include/url.h
+++ b/include/url.h
@@ -274,6 +274,11 @@ namespace Url
          */
         void split_sort_join(std::string& str, const char glue);
 
+        /**
+         * Check that the hostname is valid, removing an optional trailing '.'.
+         */
+        void check_hostname(std::string& host);
+
         std::string scheme_;
         std::string host_;
         int port_;

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -1154,3 +1154,39 @@ TEST(PunycodeTest, Safe)
     std::string encoded("http://safe.segments/");
     EXPECT_EQ(encoded, Url::Url(unencoded).punycode().str());
 }
+
+TEST(PunycodeTest, SingleDot)
+{
+    ASSERT_THROW(Url::Url("http://./").punycode(), std::invalid_argument);
+}
+
+TEST(PunycodeTest, EmptySegment)
+{
+    ASSERT_THROW(Url::Url("http://foo..com/").punycode(), std::invalid_argument);
+}
+
+TEST(PunycodeTest, TrailingEmptySegment)
+{
+    ASSERT_THROW(Url::Url("http://foo../").punycode(), std::invalid_argument);
+}
+
+TEST(PunycodeTest, TrailingPeriod)
+{
+    std::string unencoded("http://foo.com./");
+    std::string encoded("http://foo.com/");
+    EXPECT_EQ(encoded, Url::Url(unencoded).punycode().str());
+}
+
+TEST(PunycodeTest, SegmentTooLong)
+{
+    std::string unencoded(
+        "http://this-is-a-very-long-segment-that-has-more-than-sixty-three-characters.com/");
+    ASSERT_THROW(Url::Url(unencoded).punycode(), std::invalid_argument);
+}
+
+TEST(PunycodeTest, TrailingSegmentTooLong)
+{
+    std::string unencoded(
+        "http://this-is-a-very-long-segment-that-has-more-than-sixty-three-characters/");
+    ASSERT_THROW(Url::Url(unencoded).punycode(), std::invalid_argument);
+}


### PR DESCRIPTION
One issue I ran into when trying to pull `batleth` up to the new `url-py` was that the Python IDNA codec checks to make sure segments aren't too long and aren't empty. Replicate this functionality here.

@b4hand @tammybailey @lindseyreno 
