### PR TITLE
Handle javascript, mailto, and friends

### DIFF
--- a/include/url.h
+++ b/include/url.h
@@ -63,6 +63,9 @@ namespace Url
         const static CharacterClass SCHEME;
         const static std::vector<signed char> HEX_TO_DEC;
         const static std::unordered_map<std::string, int> PORTS;
+        const static std::unordered_set<std::string> USES_RELATIVE;
+        const static std::unordered_set<std::string> USES_NETLOC;
+        const static std::unordered_set<std::string> USES_PARAMS;
 
         // The type of the predicate used for removing parameters
         typedef std::function<bool(std::string&, std::string&)> deparam_predicate;

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -396,6 +396,13 @@ namespace Url
     {
         std::string copy;
         std::vector<size_t> segment_starts;
+
+        if (path_.size() >= 1 && path_[0] == '/')
+        {
+            copy.append(1, '/');
+            segment_starts.push_back(0);
+        }
+
         bool directory = false;
         size_t previous = 0;
         size_t index = 0;
@@ -427,8 +434,8 @@ namespace Url
             else
             {
                 segment_starts.push_back(copy.length());
-                copy.append(1, '/');
                 copy.append(path_, previous, index - previous);
+                copy.append(1, '/');
                 directory = false;
             }
         }
@@ -455,12 +462,16 @@ namespace Url
         }
         else
         {
-            copy.append(1, '/');
             copy.append(path_, previous, index - previous);
+            copy.append(1, '/');
             directory = false;
         }
 
-        if (directory)
+        if (!directory && copy.size() >= 1)
+        {
+            copy.resize(copy.size() - 1);
+        }
+        else if (directory && copy.empty())
         {
             copy.append(1, '/');
         }

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -325,7 +325,14 @@ namespace Url
         if (!scheme_.empty())
         {
             result.append(scheme_);
-            result.append("://");
+            if (USES_NETLOC.find(scheme_) == USES_NETLOC.end())
+            {
+                result.append(":");
+            }
+            else
+            {
+                result.append("://");
+            }
         }
         else if (!host_.empty())
         {

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -65,6 +65,67 @@ namespace Url
         {"http", 80},
         {"https", 443}
     };
+    const std::unordered_set<std::string> Url::USES_RELATIVE = {
+        "",
+        "file",
+        "ftp",
+        "gopher",
+        "http",
+        "https",
+        "imap",
+        "mms",
+        "nntp",
+        "prospero",
+        "rtsp",
+        "rtspu",
+        "sftp",
+        "shttp",
+        "svn",
+        "svn+ssh",
+        "wais"
+    };
+    const std::unordered_set<std::string> Url::USES_NETLOC = {
+        "",
+        "file",
+        "ftp",
+        "git",
+        "git+ssh",
+        "gopher",
+        "http",
+        "https",
+        "imap",
+        "mms",
+        "nfs",
+        "nntp",
+        "prospero",
+        "rsync",
+        "rtsp",
+        "rtspu",
+        "sftp",
+        "shttp",
+        "snews",
+        "svn",
+        "svn+ssh",
+        "telnet",
+        "wais"
+    };
+    const std::unordered_set<std::string> Url::USES_PARAMS = {
+        "",
+        "ftp",
+        "hdl",
+        "http",
+        "https",
+        "imap",
+        "mms",
+        "prospero",
+        "rtsp",
+        "rtspu",
+        "sftp",
+        "shttp",
+        "sip",
+        "sips",
+        "tel"
+    };
 
     Url::Url(const std::string& url): port_(0)
     {

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -468,6 +468,12 @@ namespace Url
 
     Url& Url::relative_to(const Url& other)
     {
+        // If this scheme does not use relative, return it unchanged
+        if (USES_RELATIVE.find(scheme_) == USES_RELATIVE.end())
+        {
+            return *this;
+        }
+
         // Support scheme-relative URLs
         if (scheme_.empty())
         {

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -244,12 +244,15 @@ namespace Url
                 path_.resize(index);
             }
 
-            index = path_.find(';');
-            if (index != std::string::npos)
+            if (USES_PARAMS.find(scheme_) != USES_PARAMS.end())
             {
-                params_.assign(path_, index + 1, std::string::npos);
-                remove_repeats(params_, ';');
-                path_.resize(index);
+                index = path_.find(';');
+                if (index != std::string::npos)
+                {
+                    params_.assign(path_, index + 1, std::string::npos);
+                    remove_repeats(params_, ';');
+                    path_.resize(index);
+                }
             }
         }
     }

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -368,6 +368,10 @@ namespace Url
         }
         else
         {
+            if (!host_.empty() && path_[0] != '/')
+            {
+                result.append(1, '/');
+            }
             result.append(path_);
         }
 

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -602,7 +602,7 @@ TEST(AbspathTest, GrandparentDirectory)
 
 TEST(AbspathTest, UpMoreLevelsThanSegments)
 {
-    EXPECT_EQ("/c",
+    EXPECT_EQ("c",
         Url::Url("http://foo.com/../../../c").abspath().path());
 }
 
@@ -676,6 +676,12 @@ TEST(AbspathTest, TrailingDotInSegment)
 {
     EXPECT_EQ("/foo/whiz./bar",
         Url::Url("http://foo.com//foo/whiz./bar").abspath().path());
+}
+
+TEST(AbspathTest, DoesNotUseNetloc)
+{
+    EXPECT_EQ("console.log('hello')",
+        Url::Url("javascript:console.log('hello')").abspath().path());
 }
 
 TEST(RelativeTest, SchemeRelative)

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -227,6 +227,20 @@ TEST(ParseTest, TestEmptyPort)
     EXPECT_EQ("http://www.python.org/", parsed.str());
 }
 
+TEST(ParseTest, DoesNotUseNetloc)
+{
+    Url::Url parsed("javascript:console.log('hello')");
+    EXPECT_EQ("javascript", parsed.scheme());
+    EXPECT_EQ("", parsed.userinfo());
+    EXPECT_EQ("", parsed.host());
+    EXPECT_EQ(0, parsed.port());
+    EXPECT_EQ("console.log('hello')", parsed.path());
+    EXPECT_EQ("", parsed.params());
+    EXPECT_EQ("", parsed.query());
+    EXPECT_EQ("", parsed.fragment());
+    EXPECT_EQ("javascript:console.log('hello')", parsed.str());
+}
+
 TEST(ParseTest, TestIllegalPort)
 {
     ASSERT_THROW(Url::Url("http://www.python.org:65536/"), Url::UrlParseException);

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -867,6 +867,20 @@ TEST(RelativeTest, BaseWithDirectory)
         Url::Url("relative").relative_to(base).str());
 }
 
+TEST(RelativeTest, RelativeSchemeDoesntUseRelative)
+{
+    Url::Url base("http://foo.com/path");
+    EXPECT_EQ("javascript:console.log(\"hello\")",
+        Url::Url("javascript:console.log(\"hello\")").relative_to(base).str());
+}
+
+TEST(RelativeTest, BaseSchemeDoesntUseRelative)
+{
+    Url::Url base("javascript:console.log(\"hello\")");
+    EXPECT_EQ("http://foo.com/path",
+        Url::Url("http://foo.com/path").relative_to(base).str());
+}
+
 TEST(EscapeTest, IncompleteEntity)
 {
     EXPECT_EQ("trailing-incomplete%252",

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -572,116 +572,173 @@ TEST(ParamTest, SanitizesParams)
 
 TEST(AbspathTest, BasicPath)
 {
+    std::string example("http://foo.com/howdy");
     EXPECT_EQ("/howdy",
-        Url::Url("http://foo.com/howdy").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/howdy",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, RepeatedSeparator)
 {
+    std::string example("http://foo.com/hello//how//are");
     EXPECT_EQ("/hello/how/are",
-        Url::Url("http://foo.com/hello//how//are").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/hello/how/are",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, ParentDirectory)
 {
+    std::string example("http://foo.com/hello/../how/are");
     EXPECT_EQ("/how/are",
-        Url::Url("http://foo.com/hello/../how/are").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/how/are",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, ParentDirectoryWithRepeatedSeparators)
 {
+    std::string example("http://foo.com/hello//..//how/");
     EXPECT_EQ("/how/",
-        Url::Url("http://foo.com/hello//..//how/").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/how/",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, GrandparentDirectory)
 {
+    std::string example("http://foo.com/a/b/../../c");
     EXPECT_EQ("/c",
-        Url::Url("http://foo.com/a/b/../../c").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/c",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, UpMoreLevelsThanSegments)
 {
+    std::string example("http://foo.com/../../../c");
     EXPECT_EQ("c",
-        Url::Url("http://foo.com/../../../c").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/c",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, CurrentDirectory)
 {
+    std::string example("http://foo.com/./hello");
     EXPECT_EQ("/hello",
-        Url::Url("http://foo.com/./hello").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/hello",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, CurrentDirectoryRepeated)
 {
+    std::string example("http://foo.com/./././hello");
     EXPECT_EQ("/hello",
-        Url::Url("http://foo.com/./././hello").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/hello",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, MultipleSegmentsDirectory)
 {
+    std::string example("http://foo.com/a/b/c/");
     EXPECT_EQ("/a/b/c/",
-        Url::Url("http://foo.com/a/b/c/").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/a/b/c/",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, TrailingParentDirectory)
 {
+    std::string example("http://foo.com/a/b/c/..");
     EXPECT_EQ("/a/b/",
-        Url::Url("http://foo.com/a/b/c/..").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/a/b/",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, TrailingCurrentDirectory)
 {
+    std::string example("http://foo.com/a/b/.");
     EXPECT_EQ("/a/b/",
-        Url::Url("http://foo.com/a/b/.").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/a/b/",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, TrailingCurrentDirectoryMultiple)
 {
+    std::string example("http://foo.com/a/b/./././");
     EXPECT_EQ("/a/b/",
-        Url::Url("http://foo.com/a/b/./././").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/a/b/",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, TrailingParentDirectorySlash)
 {
+    std::string example("http://foo.com/a/b/../");
     EXPECT_EQ("/a/",
-        Url::Url("http://foo.com/a/b/../").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/a/",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, OnlyCurrentDirectory)
 {
+    std::string example("http://foo.com/.");
     EXPECT_EQ("/",
-        Url::Url("http://foo.com/.").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, OnlyMultipleParentDirectories)
 {
+    std::string example("http://foo.com/../../..");
     EXPECT_EQ("/",
-        Url::Url("http://foo.com/../../..").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, TrailingDotInLastSegment)
 {
+    std::string example("http://foo.com//foo/../whiz.");
     EXPECT_EQ("/whiz.",
-        Url::Url("http://foo.com//foo/../whiz.").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/whiz.",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, TrailingDotInSegmentSlash)
 {
+    std::string example("http://foo.com//foo/whiz./");
     EXPECT_EQ("/foo/whiz./",
-        Url::Url("http://foo.com//foo/whiz./").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/foo/whiz./",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, TrailingDotInSegment)
 {
+    std::string example("http://foo.com//foo/whiz./bar");
     EXPECT_EQ("/foo/whiz./bar",
-        Url::Url("http://foo.com//foo/whiz./bar").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("http://foo.com/foo/whiz./bar",
+        Url::Url(example).abspath().str());
 }
 
 TEST(AbspathTest, DoesNotUseNetloc)
 {
+    std::string example("javascript:console.log('hello')");
     EXPECT_EQ("console.log('hello')",
-        Url::Url("javascript:console.log('hello')").abspath().path());
+        Url::Url(example).abspath().path());
+    EXPECT_EQ("javascript:console.log('hello')",
+        Url::Url(example).abspath().str());
 }
 
 TEST(RelativeTest, SchemeRelative)

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -241,6 +241,20 @@ TEST(ParseTest, DoesNotUseNetloc)
     EXPECT_EQ("javascript:console.log('hello')", parsed.str());
 }
 
+TEST(ParseTest, DoesNotUseParams)
+{
+    Url::Url parsed("javascript:console.log('hello');console.log('world')");
+    EXPECT_EQ("javascript", parsed.scheme());
+    EXPECT_EQ("", parsed.userinfo());
+    EXPECT_EQ("", parsed.host());
+    EXPECT_EQ(0, parsed.port());
+    EXPECT_EQ("console.log('hello');console.log('world')", parsed.path());
+    EXPECT_EQ("", parsed.params());
+    EXPECT_EQ("", parsed.query());
+    EXPECT_EQ("", parsed.fragment());
+    EXPECT_EQ("javascript:console.log('hello');console.log('world')", parsed.str());
+}
+
 TEST(ParseTest, TestIllegalPort)
 {
     ASSERT_THROW(Url::Url("http://www.python.org:65536/"), Url::UrlParseException);


### PR DESCRIPTION
This brings `url-cpp` closer to the behavior of Python's `urlparse`, in the handling of three classes of schemes:
- those that do not use a `netloc`
- those that do not use relativization
- those that do not use `params`

Before this PR:

``` python
>>> URL.parse('http://moz.com/').relative('javascript:console.log("hello")').utf8
'javascript://moz.com/console.log("hello")'
>>> URL.parse('javascript:console.log("hello");console.log("world")').path
'console.log("hello")'
>>> URL.parse('javascript:console.log("hello");console.log("world")').params
'console.log("world")'
```

With this PR (same as `urlparse` interpretation):

``` python
>>> URL.parse('http://moz.com/').relative('javascript:console.log("hello")').utf8
'javascript:console.log("hello")'
>>> URL.parse('javascript:console.log("hello");console.log("world")').path
'console.log("hello");console.log("world")'
>>> URL.parse('javascript:console.log("hello");console.log("world")').params
''
```

@b4hand @neilmb @lindseyreno 
