### PR TITLE
Provide a `fullpath` method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,34 +2,43 @@ CPP          = g++
 CPPOPTS      = -Wall -Werror -std=c++11 -Iinclude/
 DEBUG_OPTS   = -fprofile-arcs -ftest-coverage -O0 -g -fPIC
 RELEASE_OPTS = -O3
-DEBUG_LIBS   = debug/url.o debug/utf8.o debug/punycode.o debug/psl.o
-RELEASE_LIBS = release/url.o release/utf8.o release/punycode.o release/psl.o
 
-release: $(RELEASE_LIBS)
+# Release libraries
+release:
+	mkdir -p release
+
+release/liburl.o: release/url.o release/utf8.o release/punycode.o release/psl.o
+	ld -r -o $@ $^
 
 release/%.o: src/%.cpp include/%.h
 	mkdir -p release
 	$(CPP) $(CPPOPTS) $(RELEASE_OPTS) -o $@ -c $<
 
-debug: $(DEBUG_LIBS)
+# Debug libraries
+debug:
+	mkdir -p debug
+
+debug/liburl.o: debug/url.o debug/utf8.o debug/punycode.o debug/psl.o
+	ld -r -o $@ $^
 
 debug/%.o: src/%.cpp include/%.h
 	mkdir -p debug
 	$(CPP) $(CPPOPTS) $(DEBUG_OPTS) -o $@ -c $<
 
-bench: bench.cpp release
-	$(CPP) $(CPPOPTS) $(RELEASE_OPTS) -o $@ $< $(RELEASE_LIBS)
-
+# Tests
 test/%.o: test/%.cpp
 	$(CPP) $(CPPOPTS) $(DEBUG_OPTS) -o $@ -c $<
 
-test-all: test/test-all.o test/test-url.o test/test-utf8.o test/test-punycode.o test/test-psl.o $(DEBUG_LIBS)
+test-all: test/test-all.o test/test-url.o test/test-utf8.o test/test-punycode.o test/test-psl.o debug/liburl.o
 	$(CPP) $(CPPOPTS) $(DEBUG_OPTS) -o $@ $^ -lgtest -lpthread
 
 .PHONY: test
 test: test-all
 	./test-all
 	./scripts/check-coverage.sh $(PWD)
+
+bench: bench.cpp release
+	$(CPP) $(CPPOPTS) $(RELEASE_OPTS) -o $@ $< release/liburl.o
 
 clean:
 	find . -name '*.o' -o -name '*.gcda' -o -name '*.gcno' -o -name '*.gcov' \

--- a/include/url.h
+++ b/include/url.h
@@ -158,6 +158,13 @@ namespace Url
         }
 
         /**
+         * Get a representation of all components of the path, params, query, fragment.
+         *
+         * Always includes a leading /.
+         */
+        std::string fullpath() const;
+
+        /**
          * Get a new string representation of the URL.
          **/
         std::string str() const;

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -321,6 +321,11 @@ namespace Url
         str.resize(length);
     }
 
+    std::string Url::fullpath() const
+    {
+        return "";
+    }
+
     std::string Url::str() const
     {
         std::string result;

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -323,7 +323,31 @@ namespace Url
 
     std::string Url::fullpath() const
     {
-        return "";
+        std::string result;
+        if (path_.empty() || path_[0] != '/')
+        {
+            result.append(1, '/');
+        }
+        result.append(path_);
+
+        if (!params_.empty())
+        {
+            result.append(";");
+            result.append(params_);
+        }
+
+        if (!query_.empty())
+        {
+            result.append("?");
+            result.append(query_);
+        }
+
+        if (!fragment_.empty())
+        {
+            result.append("#");
+            result.append(fragment_);
+        }
+        return result;
     }
 
     std::string Url::str() const

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -1213,6 +1213,45 @@ TEST(DefragTest, Defrag)
         Url::Url("http://foo.com/path#fragment").defrag().str());
 }
 
+TEST(FullpathTest, OnlyPath)
+{
+    EXPECT_EQ("/path", Url::Url("path").fullpath());
+}
+
+TEST(FullpathTest, LeadingSlashPath)
+{
+    EXPECT_EQ("/path", Url::Url("/path").fullpath());
+}
+
+TEST(FullpathTest, EmptyPath)
+{
+    EXPECT_EQ("/", Url::Url("").fullpath());
+}
+
+TEST(FullpathTest, Params)
+{
+    EXPECT_EQ("/;params",
+        Url::Url(";params").fullpath());
+}
+
+TEST(FullpathTest, Query)
+{
+    EXPECT_EQ("/?query",
+        Url::Url("?query").fullpath());
+}
+
+TEST(FullpathTest, Fragment)
+{
+    EXPECT_EQ("/#fragment",
+        Url::Url("#fragment").fullpath());
+}
+
+TEST(FullpathTest, ParamsAndFriends)
+{
+    EXPECT_EQ("/path;params?query#fragment",
+        Url::Url("/path;params?query#fragment").fullpath());
+}
+
 TEST(PunycodeTest, German)
 {
     std::string unencoded("http://www.kündigen.de/");


### PR DESCRIPTION
For dealing with `robots.txt`, a common use-case is to ask if a particular URL is allowed, though `robots.txt` rules deal with paths. As such, it's handy to have a method that takes a URL and provides a full path, including the path, params, query and fragment components:

```
// To help answer the question "is http://example.com/path;params?query#fragment allowed?"
std::string url = "http://example.com/path;params?query#fragment allowed";
std::string path = Url::Url(url).defrag().fullpath();
// Check if path is allowed according to robots.txt
```

@b4hand @arora-richa @tammybailey
