### PR TITLE
Don't eagerly remove semantically meaningless characters from queries and params

### DIFF
--- a/include/url.h
+++ b/include/url.h
@@ -80,7 +80,9 @@ namespace Url
             , params_(other.params_)
             , query_(other.query_)
             , fragment_(other.fragment_)
-            , userinfo_(other.userinfo_) { }
+            , userinfo_(other.userinfo_)
+            , has_params_(other.has_params_)
+            , has_query_(other.has_query_) { }
 
         /**
          * Take on the value of the other URL.
@@ -133,6 +135,7 @@ namespace Url
         Url& setParams(const std::string& s)
         {
             params_ = s;
+            has_params_ = !s.empty();
             return *this;
         }
 
@@ -140,6 +143,7 @@ namespace Url
         Url& setQuery(const std::string& s)
         {
             query_ = s;
+            has_query_ = !s.empty();
             return *this;
         }
 
@@ -262,27 +266,28 @@ namespace Url
         /**
          * Remove repeated, leading, and trailing instances of chr from the string.
          */
-        void remove_repeats(std::string& str, const char chr);
+        std::string& remove_repeats(std::string& str, const char chr);
 
         /**
          * Ensure all the provided characters are escaped if necessary
          */
-        void escape(std::string& str, const CharacterClass& safe, bool strict);
+        std::string& escape(std::string& str, const CharacterClass& safe, bool strict);
 
         /**
          * Unescape entities in the provided string
          */
-        void unescape(std::string& str);
+        std::string& unescape(std::string& str);
 
         /**
          * Remove any params that match entries in the blacklist.
          */
-        void remove_params(std::string& str, const deparam_predicate& pred, char sep);
+        std::string& remove_params(
+            std::string& str, const deparam_predicate& pred, char sep);
 
         /**
          * Split the provided string by char, sort, join by char.
          */
-        void split_sort_join(std::string& str, const char glue);
+        std::string& split_sort_join(std::string& str, const char glue);
 
         /**
          * Check that the hostname is valid, removing an optional trailing '.'.
@@ -297,6 +302,8 @@ namespace Url
         std::string query_;
         std::string fragment_;
         std::string userinfo_;
+        bool has_params_;
+        bool has_query_;
     };
 
 }

--- a/include/url.h
+++ b/include/url.h
@@ -178,6 +178,12 @@ namespace Url
          *********************/
 
         /**
+         * Strip semantically meaningless excess '?', '&', and ';' characters from query
+         * and params.
+         */
+        Url& strip();
+
+        /**
          * Make the path absolute.
          *
          * Evaluate '.', '..', and excessive slashes.

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -231,18 +231,9 @@ namespace Url
             index = path_.find('?');
             if (index != std::string::npos)
             {
-                size_t start = path_.find_first_not_of('?', index + 1);
-                if (start != std::string::npos)
-                {
-                    query_.assign(path_, start, std::string::npos);
-                    remove_repeats(query_, '&');
-                }
-                else
-                {
-                    query_ = "";
-                }
-                path_.resize(index);
+                query_.assign(path_, index + 1, std::string::npos);
                 has_query_ = !query_.empty();
+                path_.resize(index);
             }
 
             if (USES_PARAMS.find(scheme_) != USES_PARAMS.end())
@@ -251,12 +242,13 @@ namespace Url
                 if (index != std::string::npos)
                 {
                     params_.assign(path_, index + 1, std::string::npos);
-                    remove_repeats(params_, ';');
+                    has_params_ = !params_.empty();
                     path_.resize(index);
                 }
-                has_params_ = !params_.empty();
             }
         }
+
+        strip();
     }
 
     Url& Url::assign(const Url& other)
@@ -428,6 +420,22 @@ namespace Url
         }
 
         return result;
+    }
+
+    Url& Url::strip()
+    {
+        size_t start = query_.find_first_not_of('?');
+        if (start != std::string::npos)
+        {
+            query_.assign(query_, start, std::string::npos);
+        }
+        else
+        {
+            query_.assign("");
+        }
+        setQuery(remove_repeats(query_, '&'));
+        setParams(remove_repeats(params_, ';'));
+        return *this;
     }
 
     Url& Url::abspath()

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -232,7 +232,7 @@ namespace Url
             if (index != std::string::npos)
             {
                 query_.assign(path_, index + 1, std::string::npos);
-                has_query_ = !query_.empty();
+                has_query_ = true;
                 path_.resize(index);
             }
 
@@ -242,13 +242,11 @@ namespace Url
                 if (index != std::string::npos)
                 {
                     params_.assign(path_, index + 1, std::string::npos);
-                    has_params_ = !params_.empty();
+                    has_params_ = true;
                     path_.resize(index);
                 }
             }
         }
-
-        strip();
     }
 
     Url& Url::assign(const Url& other)
@@ -282,14 +280,16 @@ namespace Url
         Url self_(*this);
         Url other_(other);
 
-        self_.sort_query()
+        self_.strip()
+             .sort_query()
              .defrag()
              .deuserinfo()
              .abspath()
              .escape()
              .punycode()
              .remove_default_port();
-        other_.sort_query()
+        other_.strip()
+              .sort_query()
               .defrag()
               .deuserinfo()
               .abspath()

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -567,7 +567,8 @@ namespace Url
                 has_params_ = other.has_params_;
                 if (query_.empty())
                 {
-                    setQuery(other.query_);
+                    query_ = other.query_;
+                    has_query_ = other.has_query_;
                 }
             }
             else
@@ -599,8 +600,8 @@ namespace Url
     Url& Url::escape(bool strict)
     {
         escape(path_, PATH, strict);
-        setQuery(escape(query_, QUERY, strict));
-        setParams(escape(params_, QUERY, strict));
+        escape(query_, QUERY, strict);
+        escape(params_, QUERY, strict);
         escape(userinfo_, USERINFO, strict);
         return *this;
     }
@@ -661,8 +662,8 @@ namespace Url
     Url& Url::unescape()
     {
         unescape(path_);
-        setQuery(unescape(query_));
-        setParams(unescape(params_));
+        unescape(query_);
+        unescape(params_);
         unescape(userinfo_);
         return *this;
     }
@@ -771,8 +772,8 @@ namespace Url
 
     Url& Url::sort_query()
     {
-        setQuery(split_sort_join(query_, '&'));
-        setParams(split_sort_join(params_, ';'));
+        split_sort_join(query_, '&');
+        split_sort_join(params_, ';');
         return *this;
     }
 

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -1058,6 +1058,16 @@ TEST(EscapeTest, StrictPreservesSafeButReservedEntities)
         Url::Url("path%27s-ok").escape(true).str());
 }
 
+TEST(EscapeTest, PreservesHasQuery)
+{
+    EXPECT_EQ("/path?", Url::Url("/path?").escape(true).str());
+}
+
+TEST(EscapeTest, PreservesHasParams)
+{
+    EXPECT_EQ("/path;", Url::Url("/path;").escape(true).str());
+}
+
 TEST(EscapeTest, PermissiveFromUrlPy)
 {
     EXPECT_EQ("danny\'s%20pub",
@@ -1125,6 +1135,16 @@ TEST(UnescapeTest, NonHexEntity)
         Url::Url("a%20non%20hex%20%gh%20entity").unescape().str());
 }
 
+TEST(UnescapeTest, PreservesHasQuery)
+{
+    EXPECT_EQ("/path?", Url::Url("/path?").unescape().str());
+}
+
+TEST(UnescapeTest, PreservesHasParams)
+{
+    EXPECT_EQ("/path;", Url::Url("/path;").unescape().str());
+}
+
 TEST(UnescapeTest, UnescapesEverything)
 {
     std::string escaped =
@@ -1155,6 +1175,18 @@ TEST(FilterParams, CaseInsensitivity)
     std::unordered_set<std::string> blacklist = {"hello"};
     EXPECT_EQ("", Url::Url("?hELLo=2").deparam(blacklist).str());
     EXPECT_EQ("", Url::Url("?HELLo=2").deparam(blacklist).str());
+}
+
+TEST(FilterParams, RemovesEmptyQuery)
+{
+    std::unordered_set<std::string> blacklist = {"hello"};
+    EXPECT_EQ("/path", Url::Url("/path?").deparam(blacklist).str());
+}
+
+TEST(FilterParams, RemovesEmptyParams)
+{
+    std::unordered_set<std::string> blacklist = {"hello"};
+    EXPECT_EQ("/path", Url::Url("/path;").deparam(blacklist).str());
 }
 
 TEST(FilterParams, PredicateFormQuery)

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -255,6 +255,34 @@ TEST(ParseTest, DoesNotUseParams)
     EXPECT_EQ("javascript:console.log('hello');console.log('world')", parsed.str());
 }
 
+TEST(ParseTest, EmptyQuery)
+{
+    Url::Url parsed("http://example.com/?");
+    EXPECT_EQ("http", parsed.scheme());
+    EXPECT_EQ("", parsed.userinfo());
+    EXPECT_EQ("example.com", parsed.host());
+    EXPECT_EQ(0, parsed.port());
+    EXPECT_EQ("/", parsed.path());
+    EXPECT_EQ("", parsed.params());
+    EXPECT_EQ("", parsed.query());
+    EXPECT_EQ("", parsed.fragment());
+    EXPECT_EQ("http://example.com/?", parsed.str());
+}
+
+TEST(ParseTest, EmptyParams)
+{
+    Url::Url parsed("http://example.com/;");
+    EXPECT_EQ("http", parsed.scheme());
+    EXPECT_EQ("", parsed.userinfo());
+    EXPECT_EQ("example.com", parsed.host());
+    EXPECT_EQ(0, parsed.port());
+    EXPECT_EQ("/", parsed.path());
+    EXPECT_EQ("", parsed.params());
+    EXPECT_EQ("", parsed.query());
+    EXPECT_EQ("", parsed.fragment());
+    EXPECT_EQ("http://example.com/;", parsed.str());
+}
+
 TEST(ParseTest, TestIllegalPort)
 {
     ASSERT_THROW(Url::Url("http://www.python.org:65536/"), Url::UrlParseException);
@@ -554,20 +582,20 @@ TEST(HostnameTest, LowercasesHostname)
 
 TEST(QueryTest, SanitizesQuery)
 {
-    EXPECT_EQ("a=1&b=2"    , Url::Url("http://foo.com/?a=1&&&&&&b=2"   ).query());
-    EXPECT_EQ("foo=2"      , Url::Url("http://foo.com/????foo=2"       ).query());
-    EXPECT_EQ("foo=2"      , Url::Url("http://foo.com/?foo=2&&&"       ).query());
-    EXPECT_EQ("query?"     , Url::Url("http://foo.com/?query?"         ).query());
-    EXPECT_EQ("repeats???q", Url::Url("http://foo.com/?repeats???q"    ).query());
-    EXPECT_EQ(""           , Url::Url("http://foo.com/?????"           ).query());
+    EXPECT_EQ("a=1&b=2"    , Url::Url("http://foo.com/?a=1&&&&&&b=2"   ).strip().query());
+    EXPECT_EQ("foo=2"      , Url::Url("http://foo.com/????foo=2"       ).strip().query());
+    EXPECT_EQ("foo=2"      , Url::Url("http://foo.com/?foo=2&&&"       ).strip().query());
+    EXPECT_EQ("query?"     , Url::Url("http://foo.com/?query?"         ).strip().query());
+    EXPECT_EQ("repeats???q", Url::Url("http://foo.com/?repeats???q"    ).strip().query());
+    EXPECT_EQ(""           , Url::Url("http://foo.com/?????"           ).strip().query());
 }
 
 TEST(ParamTest, SanitizesParams)
 {
-    EXPECT_EQ(""           , Url::Url("http://foo.com/"                ).params());
-    EXPECT_EQ("a=1;b=2"    , Url::Url("http://foo.com/;a=1;;;;;;b=2"   ).params());
-    EXPECT_EQ("a=1;b=2"    , Url::Url("http://foo.com/;;;a=1;;;;;;b=2" ).params());
-    EXPECT_EQ("a=1;b=2"    , Url::Url("http://foo.com/;a=1;;;;;;b=2;;;").params());
+    EXPECT_EQ(""           , Url::Url("http://foo.com/"                ).strip().params());
+    EXPECT_EQ("a=1;b=2"    , Url::Url("http://foo.com/;a=1;;;;;;b=2"   ).strip().params());
+    EXPECT_EQ("a=1;b=2"    , Url::Url("http://foo.com/;;;a=1;;;;;;b=2" ).strip().params());
+    EXPECT_EQ("a=1;b=2"    , Url::Url("http://foo.com/;a=1;;;;;;b=2;;;").strip().params());
 }
 
 TEST(AbspathTest, BasicPath)
@@ -1250,6 +1278,16 @@ TEST(FullpathTest, ParamsAndFriends)
 {
     EXPECT_EQ("/path;params?query#fragment",
         Url::Url("/path;params?query#fragment").fullpath());
+}
+
+TEST(FullpathTest, EmptyQuery)
+{
+    EXPECT_EQ("/?", Url::Url("?").fullpath());
+}
+
+TEST(FullpathTest, EmptyParams)
+{
+    EXPECT_EQ("/;", Url::Url(";").fullpath());
 }
 
 TEST(PunycodeTest, German)


### PR DESCRIPTION
Introduce a new function, `strip()` which does what used to be automatic -- the removal of meaningless excess `?`'s and `&`'s from queries and `;`'s from params.

@b4hand @neilmb @lindseyreno 