### PR TITLE
Reverse the hostname

### DIFF
--- a/include/url.h
+++ b/include/url.h
@@ -265,6 +265,11 @@ namespace Url
          */
         Url& unpunycode();
 
+        /**
+         * Reverse the hostname (a.b.c.d => d.c.b.a)
+         */
+        Url& host_reversed();
+
     private:
         // Private, unimplemented to prevent use.
         Url();

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -856,6 +856,20 @@ namespace Url
 
     Url& Url::host_reversed()
     {
+        std::reverse(host_.begin(), host_.end());
+        for (size_t index = 0, position = 0; index < host_.size(); index = position + 1)
+        {
+            position = host_.find('.', index);
+            if (position == std::string::npos)
+            {
+                std::reverse(host_.begin() + index, host_.end());
+                break;
+            }
+            else
+            {
+                std::reverse(host_.begin() + index, host_.begin() + position);
+            }
+        }
         return *this;
     }
 

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -854,6 +854,11 @@ namespace Url
         return *this;
     }
 
+    Url& Url::host_reversed()
+    {
+        return *this;
+    }
+
     void Url::check_hostname(std::string& host)
     {
         // Skip empty hostnames -- they are valid

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -1322,6 +1322,24 @@ TEST(FullpathTest, EmptyParams)
     EXPECT_EQ("/;", Url::Url(";").fullpath());
 }
 
+TEST(HostReversedTest, Basic)
+{
+    EXPECT_EQ("http://com.example/path",
+        Url::Url("http://example.com/path").host_reversed().str());
+}
+
+TEST(HostReversedTest, Empty)
+{
+    EXPECT_EQ("/path",
+        Url::Url("/path").host_reversed().str());
+}
+
+TEST(HostReversedTest, Reversible)
+{
+    EXPECT_EQ("http://example.com/path",
+        Url::Url("http://example.com/path").host_reversed().host_reversed().str());
+}
+
 TEST(PunycodeTest, German)
 {
     std::string unencoded("http://www.kündigen.de/");


### PR DESCRIPTION
For certain applications, we'd like to be able to reverse the hostname of a URL. As in `example.com` -> `com.example`. This makes schemeless URLs easily grouped by lexicographically sorting them.

@b4hand @neilmb @sistawendy 