### PR TITLE
BIG-3640 - Tel Protocol

### DIFF
--- a/include/url.h
+++ b/include/url.h
@@ -66,6 +66,7 @@ namespace Url
         const static std::unordered_set<std::string> USES_RELATIVE;
         const static std::unordered_set<std::string> USES_NETLOC;
         const static std::unordered_set<std::string> USES_PARAMS;
+        const static std::unordered_set<std::string> KNOWN_PROTOCOLS;
 
         // The type of the predicate used for removing parameters
         typedef std::function<bool(std::string&, std::string&)> deparam_predicate;

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -126,6 +126,36 @@ namespace Url
         "sips",
         "tel"
     };
+    const std::unordered_set<std::string> Url::KNOWN_PROTOCOLS = {
+        "",
+        "file",
+        "ftp",
+        "git",
+        "git+ssh",
+        "gopher",
+        "hdl",
+        "http",
+        "https",
+        "imap",
+        "mms",
+        "nfs",
+        "nntp",
+        "prospero",
+        "rsync",
+        "rtsp",
+        "rtspu",
+        "sftp",
+        "shttp",
+        "sip",
+        "sips",
+        "sms",
+        "snews",
+        "svn",
+        "svn+ssh",
+        "tel",
+        "telnet",
+        "wais"
+    };
 
     Url::Url(const std::string& url): port_(0), has_params_(false), has_query_(false)
     {
@@ -151,6 +181,20 @@ namespace Url
                     std::transform(
                         scheme_.begin(), scheme_.end(), scheme_.begin(), ::tolower);
                     position = index + 1;
+                }
+                else
+                {
+                    scheme_.assign(url, 0, index);
+                    std::transform(
+                        scheme_.begin(), scheme_.end(), scheme_.begin(), ::tolower);
+                    if (KNOWN_PROTOCOLS.find(scheme_) != KNOWN_PROTOCOLS.end())
+                    {
+                        position = index + 1;
+                    }
+                    else
+                    {
+                        scheme_.clear();
+                    }
                 }
             }
         }

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -283,6 +283,34 @@ TEST(ParseTest, EmptyParams)
     EXPECT_EQ("http://example.com/;", parsed.str());
 }
 
+TEST(ParseTest, TelProtocol)
+{
+    Url::Url parsed("tel:0108202201");
+    EXPECT_EQ("tel", parsed.scheme());
+    EXPECT_EQ("", parsed.userinfo());
+    EXPECT_EQ("", parsed.host());
+    EXPECT_EQ(0, parsed.port());
+    EXPECT_EQ("0108202201", parsed.path());
+    EXPECT_EQ("", parsed.params());
+    EXPECT_EQ("", parsed.query());
+    EXPECT_EQ("", parsed.fragment());
+    EXPECT_EQ("tel:0108202201", parsed.str());
+}
+
+TEST(ParseTest, UnknownProtocol)
+{
+    Url::Url parsed("unknown:0108202201");
+    EXPECT_EQ("", parsed.scheme());
+    EXPECT_EQ("", parsed.userinfo());
+    EXPECT_EQ("", parsed.host());
+    EXPECT_EQ(0, parsed.port());
+    EXPECT_EQ("unknown:0108202201", parsed.path());
+    EXPECT_EQ("", parsed.params());
+    EXPECT_EQ("", parsed.query());
+    EXPECT_EQ("", parsed.fragment());
+    EXPECT_EQ("unknown:0108202201", parsed.str());
+}
+
 TEST(ParseTest, TestIllegalPort)
 {
     ASSERT_THROW(Url::Url("http://www.python.org:65536/"), Url::UrlParseException);


### PR DESCRIPTION
This is a long-standing bug, but not one that has impacted us very much.

Bear in mind that this is a C++ port of the interpretation given in the original `url-py`, which historically relied on `urlparse`. This is especially true when considering the parsing of URLs. This particular part of the original parsing uses the rule: if we find a `:`, and there's either nothing after it or at least one non-digit, the scheme is the part before the `:`.

To be as minimally disruptive as possible, this just adds support for a category of known schemes that override that determination. For instance, links like `tel:12345` were obviously failing that test.

@lindseyreno @b4hand @tammybailey 