### PR TITLE
Run `apt-get update` before `apt-get install`.

### DIFF
--- a/scripts/vagrant/provision.sh
+++ b/scripts/vagrant/provision.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+sudo apt-get update
 sudo apt-get install -y clang-3.5 g++ libgtest-dev cmake python-pip
 
 sudo pip install gcovr==3.2


### PR DESCRIPTION
If you don't run `apt-get update` first, you may try to install stale package versions which are no longer available on the public repositories. This was causing the provisioning to fail with "404 Not Found" on several packages when I tried to run `vagrant up`.