### PR TITLE
'file:///' resolve fix on Windows

### DIFF
--- a/src/url.cpp
+++ b/src/url.cpp
@@ -211,7 +211,7 @@ namespace Url
             position = index;
 
             if (    host_.empty()
-                    && (url.length() - position) >= 0
+                    && static_cast<int>(url.length() - position) >= 0
                     && url[position] == '/')
             {
                 position++;

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -210,6 +210,13 @@ namespace Url
             host_.assign(url, position, index - position);
             position = index;
 
+            if (    host_.empty()
+                    && (url.length() - position) >= 0
+                    && url[position] == '/')
+            {
+                position++;
+            }
+
             // Extract any userinfo if there is any
             index = host_.find('@');
             if (index != std::string::npos)
@@ -443,7 +450,7 @@ namespace Url
         }
         else
         {
-            if (!host_.empty() && path_[0] != '/')
+            if (path_[0] != '/')
             {
                 result.append(1, '/');
             }


### PR DESCRIPTION
Problem with Windows paths. After path parsing disk name (e.g. 'C') becomes host and path starts with '/' and not with ':/'. Url::str() method returns something like this: "C/tmp" but not "C:/tmp".