### PR TITLE
Added the missing <limits> include

### DIFF
--- a/include/punycode.h
+++ b/include/punycode.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <unordered_map>
 #include <unordered_set>
+#include <limits>
 
 #include "utf8.h"
 


### PR DESCRIPTION
Not all compilers add the `<limits>` library, which contains `std::numeric_limits`.